### PR TITLE
User/login Test코드 추가 및 auth 방식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'com.google.code.gson:gson:2.8.7'
 
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'com.google.code.gson:gson:2.8.7'
 
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
+	testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/aeon/hadog/base/code/ErrorCode.java
+++ b/src/main/java/com/aeon/hadog/base/code/ErrorCode.java
@@ -19,8 +19,10 @@ public enum ErrorCode {
      */
     INVALID_LOGIN(HttpStatus.FORBIDDEN, "아이디 또는 비밀번호가 잘못 입력되었습니다."),
     PASSWORD_MISMATCH(HttpStatus.FORBIDDEN, "비밀번호가 잘못 입력되었습니다."),
+    PASSWORD_FORMAT_INVALID(HttpStatus.FORBIDDEN, "새 비밀번호는 영문, 숫자, 특수문자를 포함하고 8~16자여야 합니다."),
+    NEW_PASSWORD_SAME_AS_OLD(HttpStatus.FORBIDDEN, "새 비밀번호는 이전 비밀번호와 다르게 설정해야 합니다."),
 
-    /*
+            /*
      * 404 NOT_FOUND : 잘못된 리소스 접근
      */
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 유저가 존재하지 않습니다");

--- a/src/main/java/com/aeon/hadog/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aeon/hadog/base/exception/GlobalExceptionHandler.java
@@ -50,6 +50,22 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponseDTO(ErrorCode.PASSWORD_MISMATCH));
     }
 
+    @ExceptionHandler(PasswordFormatInvalidException.class)
+    protected ResponseEntity<ErrorResponseDTO> PasswordFormatInvalidException(final PasswordFormatInvalidException e) {
+        log.error("PasswordFormatInvalidException : {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.PASSWORD_FORMAT_INVALID.getStatus().value())
+                .body(new ErrorResponseDTO(ErrorCode.PASSWORD_FORMAT_INVALID));
+    }
+
+    @ExceptionHandler(NewPasswordSameAsOldException.class)
+    protected ResponseEntity<ErrorResponseDTO> NewPasswordSameAsOldException(final NewPasswordSameAsOldException e) {
+        log.error("NewPasswordSameAsOldException : {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.NEW_PASSWORD_SAME_AS_OLD.getStatus().value())
+                .body(new ErrorResponseDTO(ErrorCode.NEW_PASSWORD_SAME_AS_OLD));
+    }
+
     @ExceptionHandler(UserNotFoundException.class)
     protected ResponseEntity<ErrorResponseDTO> UserNotFoundException(final UserNotFoundException e) {
         log.error("UserNotFoundException : {}", e.getMessage());

--- a/src/main/java/com/aeon/hadog/base/exception/NewPasswordSameAsOldException.java
+++ b/src/main/java/com/aeon/hadog/base/exception/NewPasswordSameAsOldException.java
@@ -1,0 +1,11 @@
+package com.aeon.hadog.base.exception;
+
+import com.aeon.hadog.base.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NewPasswordSameAsOldException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/aeon/hadog/base/exception/PasswordFormatInvalidException.java
+++ b/src/main/java/com/aeon/hadog/base/exception/PasswordFormatInvalidException.java
@@ -1,0 +1,11 @@
+package com.aeon.hadog.base.exception;
+
+import com.aeon.hadog.base.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PasswordFormatInvalidException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/aeon/hadog/controller/UserController.java
+++ b/src/main/java/com/aeon/hadog/controller/UserController.java
@@ -71,8 +71,8 @@ public class UserController {
     }
 
     @PatchMapping("/password")
-    public ResponseEntity<ResponseDTO> modifyPassword(@AuthenticationPrincipal String userId, @RequestParam String newPassword){
-        Boolean isModify = userService.modifyPassword(userId, newPassword);
+    public ResponseEntity<ResponseDTO> modifyPassword(@AuthenticationPrincipal String userId, @RequestParam String prevPassword,  @RequestParam String newPassword){
+        Boolean isModify = userService.modifyPassword(userId, prevPassword, newPassword);
         return ResponseEntity
                 .ok()
                 .body(new ResponseDTO<>(200, true, "패스워드 변경 완료", isModify));

--- a/src/main/java/com/aeon/hadog/controller/UserController.java
+++ b/src/main/java/com/aeon/hadog/controller/UserController.java
@@ -7,6 +7,7 @@ import com.aeon.hadog.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
@@ -70,8 +71,8 @@ public class UserController {
     }
 
     @PatchMapping("/password")
-    public ResponseEntity<ResponseDTO> modifyPassword(@RequestHeader("Authorization") String token, @RequestParam String newPassword){
-        Boolean isModify = userService.modifyPassword(token, newPassword);
+    public ResponseEntity<ResponseDTO> modifyPassword(@AuthenticationPrincipal String userId, @RequestParam String newPassword){
+        Boolean isModify = userService.modifyPassword(userId, newPassword);
         return ResponseEntity
                 .ok()
                 .body(new ResponseDTO<>(200, true, "패스워드 변경 완료", isModify));
@@ -79,8 +80,8 @@ public class UserController {
 
 
     @DeleteMapping
-    public ResponseEntity<ResponseDTO> deleteUser(@RequestHeader("Authorization") String token, @RequestParam String password){
-        Boolean isDelete = userService.deleteUser(token, password);
+    public ResponseEntity<ResponseDTO> deleteUser(@AuthenticationPrincipal String userId, @RequestParam String password){
+        Boolean isDelete = userService.deleteUser(userId, password);
         return ResponseEntity
                 .ok()
                 .body(new ResponseDTO<>(200, true, "회원 탈퇴 완료", isDelete));

--- a/src/main/java/com/aeon/hadog/controller/UserController.java
+++ b/src/main/java/com/aeon/hadog/controller/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
         Boolean isexist = userService.checkId(id);
         return ResponseEntity
                 .ok()
-                .body(new ResponseDTO<>(200, true, "id값 중복 없음", isexist));
+                .body(new ResponseDTO<>(200, true, "id값 중복 확인", isexist));
     }
 
     @GetMapping("/nickName")
@@ -58,7 +58,7 @@ public class UserController {
         Boolean isexist = userService.checkNickName(nickName);
         return ResponseEntity
                 .ok()
-                .body(new ResponseDTO<>(200, true, "닉네임 중복 없음", isexist));
+                .body(new ResponseDTO<>(200, true, "닉네임 중복 확인", isexist));
     }
 
     @GetMapping("/email")
@@ -66,7 +66,7 @@ public class UserController {
         Boolean isexist = userService.checkEmail(email);
         return ResponseEntity
                 .ok()
-                .body(new ResponseDTO<>(200, true, "email 중복 없음", isexist));
+                .body(new ResponseDTO<>(200, true, "email 중복 확인", isexist));
     }
 
     @PatchMapping("/password")

--- a/src/main/java/com/aeon/hadog/controller/UserController.java
+++ b/src/main/java/com/aeon/hadog/controller/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
         String token = userService.signin(loginRequestDTO);
         return ResponseEntity
                 .ok()
-                .body(new ResponseDTO<>(200, true, null, token));
+                .body(new ResponseDTO<>(200, true, "로그인 성공", token));
     }
 
     @GetMapping("/id")
@@ -50,7 +50,7 @@ public class UserController {
         Boolean isexist = userService.checkId(id);
         return ResponseEntity
                 .ok()
-                .body(new ResponseDTO<>(200, true, null, isexist));
+                .body(new ResponseDTO<>(200, true, "id값 중복 없음", isexist));
     }
 
     @GetMapping("/nickName")
@@ -58,7 +58,7 @@ public class UserController {
         Boolean isexist = userService.checkNickName(nickName);
         return ResponseEntity
                 .ok()
-                .body(new ResponseDTO<>(200, true, null, isexist));
+                .body(new ResponseDTO<>(200, true, "닉네임 중복 없음", isexist));
     }
 
     @GetMapping("/email")
@@ -66,7 +66,7 @@ public class UserController {
         Boolean isexist = userService.checkEmail(email);
         return ResponseEntity
                 .ok()
-                .body(new ResponseDTO<>(200, true, null, isexist));
+                .body(new ResponseDTO<>(200, true, "email 중복 없음", isexist));
     }
 
     @PatchMapping("/password")
@@ -74,7 +74,7 @@ public class UserController {
         Boolean isModify = userService.modifyPassword(token, newPassword);
         return ResponseEntity
                 .ok()
-                .body(new ResponseDTO<>(200, true, null, isModify));
+                .body(new ResponseDTO<>(200, true, "패스워드 변경 완료", isModify));
     }
 
 
@@ -83,7 +83,7 @@ public class UserController {
         Boolean isDelete = userService.deleteUser(token, password);
         return ResponseEntity
                 .ok()
-                .body(new ResponseDTO<>(200, true, null, isDelete));
+                .body(new ResponseDTO<>(200, true, "회원 탈퇴 완료", isDelete));
     }
 
 }

--- a/src/main/java/com/aeon/hadog/domain/Emotion.java
+++ b/src/main/java/com/aeon/hadog/domain/Emotion.java
@@ -18,11 +18,11 @@ public class Emotion {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long emotionId;
     @Column(nullable=false)
-    private String emtion;
+    private String emotion;
 
     @Column(nullable=false, columnDefinition = "TEXT")
     private String description;
 
-    @Column(nullable=false)
+    @Column(nullable=false, columnDefinition = "TEXT")
     private String image;
 }

--- a/src/main/java/com/aeon/hadog/repository/UserRepository.java
+++ b/src/main/java/com/aeon/hadog/repository/UserRepository.java
@@ -12,6 +12,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
     Optional<User> findById(String Id);
+    Optional<User> findByUserId(Long Id);
+
 
     void deleteById(String Id);
 }

--- a/src/main/java/com/aeon/hadog/repository/UserRepository.java
+++ b/src/main/java/com/aeon/hadog/repository/UserRepository.java
@@ -2,9 +2,11 @@ package com.aeon.hadog.repository;
 
 import com.aeon.hadog.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsById(String Id);
     boolean existsByNickname(String nickname);

--- a/src/main/java/com/aeon/hadog/service/UserService.java
+++ b/src/main/java/com/aeon/hadog/service/UserService.java
@@ -76,8 +76,7 @@ public class UserService {
 
     public boolean checkEmail(String email){ return userRepository.existsByEmail(email); }
 
-    public boolean modifyPassword(String token, String newPassword){
-        String userId = jwtTokenProvider.getLoginId(token);
+    public boolean modifyPassword(String userId, String newPassword){
         User user = userRepository.findById(userId).orElseThrow(()->new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         user.setPassword(passwordEncoder.encode(newPassword));
@@ -86,8 +85,7 @@ public class UserService {
         return true;
     }
 
-    public boolean deleteUser(String token, String password){
-        String userId = jwtTokenProvider.getLoginId(token);
+    public boolean deleteUser(String userId, String password){
         User user = userRepository.findById(userId).orElseThrow(()->new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         if(!passwordEncoder.matches(password, user.getPassword())){

--- a/src/main/java/com/aeon/hadog/service/UserService.java
+++ b/src/main/java/com/aeon/hadog/service/UserService.java
@@ -18,6 +18,8 @@ import org.springframework.validation.FieldError;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @Transactional
@@ -76,8 +78,24 @@ public class UserService {
 
     public boolean checkEmail(String email){ return userRepository.existsByEmail(email); }
 
-    public boolean modifyPassword(String userId, String newPassword){
+    public boolean modifyPassword(String userId, String prevPassword, String newPassword){
         User user = userRepository.findById(userId).orElseThrow(()->new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(prevPassword, user.getPassword())) {
+            throw new PasswordMismatchException(ErrorCode.PASSWORD_MISMATCH);
+        }
+
+        String passwordRegex = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}";
+        Pattern pattern = Pattern.compile(passwordRegex);
+        Matcher matcher = pattern.matcher(newPassword);
+
+        if (!matcher.matches()) {
+            throw new PasswordFormatInvalidException(ErrorCode.PASSWORD_FORMAT_INVALID);
+        }
+
+        if (passwordEncoder.matches(newPassword, user.getPassword())) {
+            throw new NewPasswordSameAsOldException(ErrorCode.NEW_PASSWORD_SAME_AS_OLD);
+        }
 
         user.setPassword(passwordEncoder.encode(newPassword));
         userRepository.save(user);

--- a/src/test/java/com/aeon/hadog/controller/UserControllerTest.java
+++ b/src/test/java/com/aeon/hadog/controller/UserControllerTest.java
@@ -1,0 +1,161 @@
+package com.aeon.hadog.controller;
+
+import com.aeon.hadog.base.dto.user.JoinRequestDTO;
+import com.aeon.hadog.base.dto.user.LoginRequestDTO;
+import com.aeon.hadog.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+
+import static org.awaitility.Awaitility.given;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Mock
+    UserService userService;
+
+
+    @Test
+    @DisplayName("회원가입 테스트")
+    void register() throws Exception {
+        // given
+        JoinRequestDTO dto = JoinRequestDTO.builder()
+                .name("김민수")
+                .id("minsu01")
+                .password("minsu01@")
+                .nickname("김민수01")
+                .email("minsu01@gmail.com")
+                .build();
+
+        String json = new ObjectMapper().writeValueAsString(dto);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/user")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json));
+
+        // then
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("로그인 테스트")
+    void login() throws Exception {
+        // given
+        LoginRequestDTO dto = LoginRequestDTO.builder()
+                .id("minsu01")
+                .password("minsu01@")
+                .build();
+
+        String json = new ObjectMapper().writeValueAsString(dto);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/user/login")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists());
+    }
+
+    @Test
+    void checkId() throws Exception {
+        // given
+        String id = "minsu01";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/user/id").param("id", id));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data").value(true))
+                .andExpect(jsonPath("$.message").value("id값 중복 확인"));
+    }
+
+    @Test
+    void checkNickName() throws Exception {
+        // given
+        String nickName = "김민수01";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/user/nickName").param("nickName", nickName));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data").value(true))
+                .andExpect(jsonPath("$.message").value("닉네임 중복 확인"));
+    }
+
+    @Test
+    void checkEmail() throws Exception {
+        // given
+        String email = "minsu01@gmail.com";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/user/email").param("email", email));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data").value(true))
+                .andExpect(jsonPath("$.message").value("email 중복 확인"));
+    }
+
+    @Test
+    void modifyPassword() throws Exception {
+//        // given
+//        String id = "minsu01";
+//        String password = "minsu01@";
+//        String newPassword = "minsu1234@";
+//
+//        // when
+//        ResultActions resultActions = mockMvc.perform(patch("/user/password")
+//                .header("Authorization", "Bearer " + token)
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .param("newPassword", newPassword));
+//
+//        // then
+//        resultActions.andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status").value(200))
+//                .andExpect(jsonPath("$.data").value(true))
+//                .andExpect(jsonPath("$.message").value("패스워드 변경 완료"));
+    }
+
+    @Test
+    void deleteUser() {
+        // given
+
+        // when
+
+        // then
+    }
+}

--- a/src/test/java/com/aeon/hadog/controller/UserControllerTest.java
+++ b/src/test/java/com/aeon/hadog/controller/UserControllerTest.java
@@ -4,32 +4,25 @@ import com.aeon.hadog.base.dto.user.JoinRequestDTO;
 import com.aeon.hadog.base.dto.user.LoginRequestDTO;
 import com.aeon.hadog.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-
-
-import static org.awaitility.Awaitility.given;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 class UserControllerTest {
 
     @Autowired
@@ -38,17 +31,29 @@ class UserControllerTest {
     @Mock
     UserService userService;
 
-
-    @Test
-    @DisplayName("회원가입 테스트")
-    void register() throws Exception {
-        // given
+    @BeforeEach
+    void setUp(){
         JoinRequestDTO dto = JoinRequestDTO.builder()
                 .name("김민수")
                 .id("minsu01")
                 .password("minsu01@")
                 .nickname("김민수01")
                 .email("minsu01@gmail.com")
+                .build();
+
+        userService.signup(dto);
+    }
+
+    @Test
+    @DisplayName("회원가입 테스트")
+    void register() throws Exception {
+        // given
+        JoinRequestDTO dto = JoinRequestDTO.builder()
+                .name("김민지")
+                .id("minji01")
+                .password("minji01@")
+                .nickname("김민지01")
+                .email("minji01@gmail.com")
                 .build();
 
         String json = new ObjectMapper().writeValueAsString(dto);
@@ -68,8 +73,8 @@ class UserControllerTest {
     void login() throws Exception {
         // given
         LoginRequestDTO dto = LoginRequestDTO.builder()
-                .id("minsu01")
-                .password("minsu01@")
+                .id("user3")
+                .password("user3@@@")
                 .build();
 
         String json = new ObjectMapper().writeValueAsString(dto);
@@ -89,7 +94,7 @@ class UserControllerTest {
     @DisplayName("아이디 중복 테스트")
     void checkId() throws Exception {
         // given
-        String id = "minsu01";
+        String id = "user3";
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/user/id").param("id", id));
@@ -105,7 +110,7 @@ class UserControllerTest {
     @DisplayName("닉네임 중복 테스트")
     void checkNickName() throws Exception {
         // given
-        String nickName = "김민수01";
+        String nickName = "hello4";
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/user/nickName").param("nickName", nickName));
@@ -121,7 +126,7 @@ class UserControllerTest {
     @DisplayName("이메일 중복 테스트")
     void checkEmail() throws Exception {
         // given
-        String email = "minsu01@gmail.com";
+        String email = "user3@gmail.com";
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/user/email").param("email", email));

--- a/src/test/java/com/aeon/hadog/controller/UserControllerTest.java
+++ b/src/test/java/com/aeon/hadog/controller/UserControllerTest.java
@@ -86,6 +86,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("아이디 중복 테스트")
     void checkId() throws Exception {
         // given
         String id = "minsu01";
@@ -101,6 +102,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("닉네임 중복 테스트")
     void checkNickName() throws Exception {
         // given
         String nickName = "김민수01";
@@ -116,6 +118,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("이메일 중복 테스트")
     void checkEmail() throws Exception {
         // given
         String email = "minsu01@gmail.com";
@@ -131,6 +134,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("비밀번호 변경 테스트")
     void modifyPassword() throws Exception {
 //        // given
 //        String id = "minsu01";
@@ -151,6 +155,7 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("회원 탈퇴 테스트")
     void deleteUser() {
         // given
 

--- a/src/test/java/com/aeon/hadog/controller/UserControllerTest.java
+++ b/src/test/java/com/aeon/hadog/controller/UserControllerTest.java
@@ -31,29 +31,16 @@ class UserControllerTest {
     @Mock
     UserService userService;
 
-    @BeforeEach
-    void setUp(){
-        JoinRequestDTO dto = JoinRequestDTO.builder()
-                .name("김민수")
-                .id("minsu01")
-                .password("minsu01@")
-                .nickname("김민수01")
-                .email("minsu01@gmail.com")
-                .build();
-
-        userService.signup(dto);
-    }
-
     @Test
     @DisplayName("회원가입 테스트")
     void register() throws Exception {
         // given
         JoinRequestDTO dto = JoinRequestDTO.builder()
-                .name("김민지")
-                .id("minji01")
-                .password("minji01@")
-                .nickname("김민지01")
-                .email("minji01@gmail.com")
+                .name("홍길동")
+                .id("user01")
+                .password("user012@")
+                .nickname("길동이01")
+                .email("user01@gmail.com")
                 .build();
 
         String json = new ObjectMapper().writeValueAsString(dto);
@@ -74,7 +61,7 @@ class UserControllerTest {
         // given
         LoginRequestDTO dto = LoginRequestDTO.builder()
                 .id("user3")
-                .password("user3@@@")
+                .password("user333!")
                 .build();
 
         String json = new ObjectMapper().writeValueAsString(dto);
@@ -142,14 +129,15 @@ class UserControllerTest {
     @DisplayName("비밀번호 변경 테스트")
     void modifyPassword() throws Exception {
 //        // given
-//        String id = "minsu01";
-//        String password = "minsu01@";
-//        String newPassword = "minsu1234@";
+//        String id = "user3";
+//        String password = "user333!";
+//        String newPassword = "user333@";
 //
 //        // when
 //        ResultActions resultActions = mockMvc.perform(patch("/user/password")
-//                .header("Authorization", "Bearer " + token)
+//                .header("Authorization", id)
 //                .contentType(MediaType.APPLICATION_JSON)
+//                .param("prevPassword", password)
 //                .param("newPassword", newPassword));
 //
 //        // then

--- a/src/test/java/com/aeon/hadog/service/UserServiceTest.java
+++ b/src/test/java/com/aeon/hadog/service/UserServiceTest.java
@@ -4,10 +4,10 @@ import com.aeon.hadog.base.dto.user.JoinRequestDTO;
 import com.aeon.hadog.base.dto.user.LoginRequestDTO;
 import com.aeon.hadog.domain.User;
 import com.aeon.hadog.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -15,16 +15,18 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
+@Transactional
 class UserServiceTest {
 
     @Autowired
     private UserService userService;
 
-    @Mock
+    @Autowired
     private UserRepository userRepository;
 
     @Test
     @DisplayName("회원가입 테스트")
+    @Transactional
     void signup() {
         // given
         JoinRequestDTO dto = JoinRequestDTO.builder()
@@ -49,8 +51,8 @@ class UserServiceTest {
     @DisplayName("로그인 테스트")
     void signin() {
         // given
-        String id = "minji01";
-        String password = "minji01@";
+        String id = "user3";
+        String password = "user3@@@";
         LoginRequestDTO dto = LoginRequestDTO.builder()
                 .id(id)
                 .password(password)
@@ -61,14 +63,13 @@ class UserServiceTest {
 
         // then
         assertNotNull(token);
-        assertEquals(182, token.length());
     }
 
     @Test
     @DisplayName("아이디 중복 테스트")
     void checkId() {
         // given
-        String existingId = "minji01";
+        String existingId = "user3";
 
         // when
         boolean result = userService.checkId(existingId);
@@ -81,7 +82,7 @@ class UserServiceTest {
     @DisplayName("닉네임 중복 테스트")
     void checkNickName() {
         // given
-        String existingNickname = "김민지01";
+        String existingNickname = "hello4";
 
         // when
         boolean result = userService.checkNickName(existingNickname);
@@ -94,7 +95,7 @@ class UserServiceTest {
     @DisplayName("이메일 중복 테스트")
     void checkEmail() {
         // given
-        String existingEmail = "minji01@gmail.com";
+        String existingEmail = "user3@gmail.com";
 
         // when
         boolean result = userService.checkEmail(existingEmail);

--- a/src/test/java/com/aeon/hadog/service/UserServiceTest.java
+++ b/src/test/java/com/aeon/hadog/service/UserServiceTest.java
@@ -1,0 +1,118 @@
+package com.aeon.hadog.service;
+
+import com.aeon.hadog.base.dto.user.JoinRequestDTO;
+import com.aeon.hadog.domain.User;
+import com.aeon.hadog.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.reactive.server.JsonPathAssertions;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+
+    @Test
+    void signup() {
+        // given
+        JoinRequestDTO joinRequestDTO = JoinRequestDTO.builder()
+                .name("김민지")
+                .id("minji01")
+                .password("minji01@")
+                .nickname("김민지01")
+                .email("minji01@gmail.com")
+                .build(); 
+
+        when(userRepository.existsById(joinRequestDTO.getId())).thenReturn(false);
+        when(userRepository.existsByNickname(joinRequestDTO.getNickname())).thenReturn(false);
+        when(userRepository.existsByEmail(joinRequestDTO.getEmail())).thenReturn(false);
+
+        // when
+        Long userId = userService.signup(joinRequestDTO);
+
+        // then
+        User findUser = userRepository.findByUserId(userId).orElseThrow();
+        assertThat(findUser.getUserId(), equalTo(userId));
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+
+    @Test
+    void signin() {
+        // given
+
+        // when
+
+        // then
+    }
+
+    @Test
+    void checkId() {
+        // given
+
+        // when
+
+        // then
+    }
+
+    @Test
+    void checkNickName() {
+        // given
+
+        // when
+
+        // then
+    }
+
+    @Test
+    void checkEmail() {
+        // given
+
+        // when
+
+        // then
+    }
+
+    @Test
+    void modifyPassword() {
+        // given
+
+        // when
+
+        // then
+    }
+
+    @Test
+    void deleteUser() {
+        // given
+
+        // when
+
+        // then
+    }
+}

--- a/src/test/java/com/aeon/hadog/service/UserServiceTest.java
+++ b/src/test/java/com/aeon/hadog/service/UserServiceTest.java
@@ -30,11 +30,11 @@ class UserServiceTest {
     void signup() {
         // given
         JoinRequestDTO dto = JoinRequestDTO.builder()
-                .name("김민지")
-                .id("minji01")
-                .password("minji01@")
-                .nickname("김민지01")
-                .email("minji01@gmail.com")
+                .name("홍길동")
+                .id("user01")
+                .password("user012@")
+                .nickname("길동이01")
+                .email("user01@gmail.com")
                 .build();
 
         // when
@@ -52,7 +52,7 @@ class UserServiceTest {
     void signin() {
         // given
         String id = "user3";
-        String password = "user3@@@";
+        String password = "user333!";
         LoginRequestDTO dto = LoginRequestDTO.builder()
                 .id(id)
                 .password(password)
@@ -108,19 +108,28 @@ class UserServiceTest {
     @DisplayName("비밀번호 변경 테스트")
     void modifyPassword() {
         // given
+        String id = "user3";
+        String prevPassword = "user333!";
+        String newPassword = "user333@";
 
         // when
+        boolean result = userService.modifyPassword(id, prevPassword, newPassword);
 
         // then
+        assertTrue(result);
     }
 
     @Test
     @DisplayName("회원 탈퇴 테스트")
     void deleteUser() {
         // given
+        String id = "user3";
+        String password = "user333!";
 
         // when
+        boolean result = userService.deleteUser(id, password);
 
         // then
+        assertTrue(result);
     }
 }

--- a/src/test/java/com/aeon/hadog/service/UserServiceTest.java
+++ b/src/test/java/com/aeon/hadog/service/UserServiceTest.java
@@ -46,7 +46,7 @@ class UserServiceTest {
                 .password("minji01@")
                 .nickname("김민지01")
                 .email("minji01@gmail.com")
-                .build(); 
+                .build();
 
         when(userRepository.existsById(joinRequestDTO.getId())).thenReturn(false);
         when(userRepository.existsByNickname(joinRequestDTO.getNickname())).thenReturn(false);

--- a/src/test/java/com/aeon/hadog/service/UserServiceTest.java
+++ b/src/test/java/com/aeon/hadog/service/UserServiceTest.java
@@ -1,46 +1,33 @@
 package com.aeon.hadog.service;
 
 import com.aeon.hadog.base.dto.user.JoinRequestDTO;
+import com.aeon.hadog.base.dto.user.LoginRequestDTO;
 import com.aeon.hadog.domain.User;
 import com.aeon.hadog.repository.UserRepository;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.web.reactive.server.JsonPathAssertions;
-import org.springframework.test.web.servlet.MockMvc;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.*;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
 
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
-@AutoConfigureMockMvc
 class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
 
     @Mock
     private UserRepository userRepository;
 
-    @Mock
-    private PasswordEncoder passwordEncoder;
-
-    @InjectMocks
-    private UserService userService;
-
-    @Autowired
-    private MockMvc mockMvc;
-
-
     @Test
+    @DisplayName("회원가입 테스트")
     void signup() {
         // given
-        JoinRequestDTO joinRequestDTO = JoinRequestDTO.builder()
+        JoinRequestDTO dto = JoinRequestDTO.builder()
                 .name("김민지")
                 .id("minji01")
                 .password("minji01@")
@@ -48,57 +35,76 @@ class UserServiceTest {
                 .email("minji01@gmail.com")
                 .build();
 
-        when(userRepository.existsById(joinRequestDTO.getId())).thenReturn(false);
-        when(userRepository.existsByNickname(joinRequestDTO.getNickname())).thenReturn(false);
-        when(userRepository.existsByEmail(joinRequestDTO.getEmail())).thenReturn(false);
-
         // when
-        Long userId = userService.signup(joinRequestDTO);
+        Long userId = userService.signup(dto);
 
         // then
-        User findUser = userRepository.findByUserId(userId).orElseThrow();
-        assertThat(findUser.getUserId(), equalTo(userId));
-        verify(userRepository, times(1)).save(any(User.class));
+        assertNotNull(userId);
+        User findUser= userRepository.findByUserId(userId).orElseThrow();
+        assertEquals(findUser.getUserId(), userId);
     }
 
 
     @Test
+    @DisplayName("로그인 테스트")
     void signin() {
         // given
+        String id = "minji01";
+        String password = "minji01@";
+        LoginRequestDTO dto = LoginRequestDTO.builder()
+                .id(id)
+                .password(password)
+                .build();
 
         // when
+        String token = userService.signin(dto);
 
         // then
+        assertNotNull(token);
+        assertEquals(182, token.length());
     }
 
     @Test
+    @DisplayName("아이디 중복 테스트")
     void checkId() {
         // given
+        String existingId = "minji01";
 
         // when
+        boolean result = userService.checkId(existingId);
 
         // then
+        assertTrue(result);
     }
 
     @Test
+    @DisplayName("닉네임 중복 테스트")
     void checkNickName() {
         // given
+        String existingNickname = "김민지01";
 
         // when
+        boolean result = userService.checkNickName(existingNickname);
 
         // then
+        assertTrue(result);
     }
 
     @Test
+    @DisplayName("이메일 중복 테스트")
     void checkEmail() {
         // given
+        String existingEmail = "minji01@gmail.com";
 
         // when
+        boolean result = userService.checkEmail(existingEmail);
 
         // then
+        assertTrue(result);
     }
 
     @Test
+    @DisplayName("비밀번호 변경 테스트")
     void modifyPassword() {
         // given
 
@@ -108,6 +114,7 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("회원 탈퇴 테스트")
     void deleteUser() {
         // given
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:testdb;NON_KEYWORDS=user
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=root
+spring.datasource.password=root
+spring.h2.console.enabled=true
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create 


### PR DESCRIPTION
## Summary
- UserControllerTest 생성
- UserServiceTest 생성
- UserController의 비밀번호 변경 메서드, 회원 탈퇴 메서드의 auth 방식 변경

## Describe your changes
- UserControllerTest와 UserServiceTest 모두 Happy Path Testing으로 진행하였습니다.
- modifyPassword와 deleteUser는 @AuthenticationPrincipal로 변경했습니다.

## Issue number and link
- close 12, 13

## Message to the reviewer