### PR TITLE
Diary Entity/Service Refacor 및 목록 기능 추가

### DIFF
--- a/src/main/java/com/aeon/hadog/controller/DiaryController.java
+++ b/src/main/java/com/aeon/hadog/controller/DiaryController.java
@@ -5,10 +5,14 @@ import com.aeon.hadog.base.dto.response.ResponseDTO;
 import com.aeon.hadog.service.DiaryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @Controller
@@ -40,5 +44,13 @@ public class DiaryController {
         return ResponseEntity
                 .ok()
                 .body(new ResponseDTO<>(200, true, "일기 수정 완료", result));
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<ResponseDTO> getDiarys(@AuthenticationPrincipal String userId, @RequestParam LocalDateTime date){
+        List<DiaryDTO> result = diaryService.getDiarys(userId, date);
+        return ResponseEntity
+                .ok()
+                .body(new ResponseDTO<>(200, true, "일기 목록 반환 완료", result));
     }
 }

--- a/src/main/java/com/aeon/hadog/domain/Diary.java
+++ b/src/main/java/com/aeon/hadog/domain/Diary.java
@@ -23,6 +23,9 @@ public class Diary {
     @JoinColumn(name = "emotion_track_id", nullable = false)
     private EmotionTrack emotionTrack;
 
+    @Column(nullable = false)
+    private Long userId;
+
     @Column(nullable=false)
     private LocalDateTime diaryDate;
 

--- a/src/main/java/com/aeon/hadog/repository/DiaryRepository.java
+++ b/src/main/java/com/aeon/hadog/repository/DiaryRepository.java
@@ -1,12 +1,20 @@
 package com.aeon.hadog.repository;
 
+import com.aeon.hadog.base.dto.diary.DiaryDTO;
 import com.aeon.hadog.domain.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Optional<Diary> findByDiaryId(Long Id);
+
+    @Query("SELECT new com.aeon.hadog.base.dto.diary.DiaryDTO(d.emotionTrack.emotionTrackId, d.diaryDate, d.content) FROM Diary d WHERE d.userId = :userId AND d.diaryDate = :date")
+    List<DiaryDTO> findDiaryDTOByUserIdAndDiaryDate(@Param("userId") Long userId, @Param("date") LocalDateTime date);
 }

--- a/src/main/java/com/aeon/hadog/service/DiaryService.java
+++ b/src/main/java/com/aeon/hadog/service/DiaryService.java
@@ -46,6 +46,7 @@ public class DiaryService {
 
         Diary diary = Diary.builder()
                 .emotionTrack(emotionTrack)
+                .userId(user.getUserId())
                 .diaryDate(diaryDTO.getDiaryDate())
                 .content(diaryDTO.getContent())
                 .build();
@@ -58,9 +59,8 @@ public class DiaryService {
     public DiaryDTO getDiary(String userId, Long diaryId){
         User user = userRepository.findById(userId).orElseThrow(()->new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
         Diary diary = diaryRepository.findByDiaryId(diaryId).orElseThrow(()->new DiaryNotFoundException(ErrorCode.DIARY_NOT_FOUND));
-        Pet pet = petRepository.findByPetId(diary.getEmotionTrack().getPetId()).orElseThrow();
 
-        if (!Objects.equals(user, pet.getUser())) {
+        if (!Objects.equals(user.getUserId(), diary.getUserId())) {
             throw new EmotionTrackNotBelongToUserException(ErrorCode.EMOTION_TRACK_NOT_BELONG_TO_USER_ERROR);
         }
 
@@ -76,9 +76,8 @@ public class DiaryService {
     public DiaryDTO modifyDiary(String userId, Long diaryId, String content){
         User user = userRepository.findById(userId).orElseThrow(()->new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
         Diary diary = diaryRepository.findByDiaryId(diaryId).orElseThrow(()->new DiaryNotFoundException(ErrorCode.DIARY_NOT_FOUND));
-        Pet pet = petRepository.findByPetId(diary.getEmotionTrack().getPetId()).orElseThrow();
 
-        if (!Objects.equals(user, pet.getUser())) {
+        if (!Objects.equals(user.getUserId(), diary.getUserId())) {
             throw new EmotionTrackNotBelongToUserException(ErrorCode.EMOTION_TRACK_NOT_BELONG_TO_USER_ERROR);
         }
 

--- a/src/main/java/com/aeon/hadog/service/DiaryService.java
+++ b/src/main/java/com/aeon/hadog/service/DiaryService.java
@@ -17,7 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -95,6 +97,14 @@ public class DiaryService {
                 .build();
 
         return diaryDTO;
+    }
+
+    public List<DiaryDTO> getDiarys(String userId, LocalDateTime date){
+        User user = userRepository.findById(userId).orElseThrow(()->new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        List<DiaryDTO> diaries = diaryRepository.findDiaryDTOByUserIdAndDiaryDate(user.getUserId(), date);
+
+        return diaries;
     }
 
     public Map<String, String> validateHandling(Errors errors) {


### PR DESCRIPTION
## Summary
- Diary Entity에 Long 타입 userId 추가했습니다.
- Entity에 맞게 Service 수정했습니다.
- 다이어리 목록 기능 추가했습니다.

## Describe your changes
- 원래 EmotionTrack에서 PetId를 통해 user를 찾았어야 했는데, userId를 추가하여 코드의 복잡성을 줄였습니다.
- 다이어리 목록 기능을 통해 해당 날짜에 쓰여진 다이어리 목록들을 불러올 수 있습니다.

## Issue number and link
#27 #28 #29 

## Message to the Reviewer
