### PR TITLE
Feat: 댓글 기능

### DIFF
--- a/src/main/java/com/aeon/hadog/base/code/ErrorCode.java
+++ b/src/main/java/com/aeon/hadog/base/code/ErrorCode.java
@@ -33,7 +33,8 @@ public enum ErrorCode {
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 일기가 존재하지 않습니다"),
     PET_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 반려견이 존재하지 않습니다"),
 
-    SHELTER_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 보호소 공고가 존재하지 않습니다");
+    SHELTER_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 보호소 공고가 존재하지 않습니다"),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 댓글이 존재하지 않습니다.");
 
     /*
      * 500 INTERNAL SERVER ERROR : 서버 에러

--- a/src/main/java/com/aeon/hadog/base/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/aeon/hadog/base/config/security/SecurityConfiguration.java
@@ -22,7 +22,7 @@ public class SecurityConfiguration {
             .httpBasic(h->h.disable())
             .sessionManagement((sessionManagement) -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests((authorizeRequests) ->
-                    authorizeRequests.requestMatchers("/", "/user/**", "/shelterPost/**").permitAll()
+                    authorizeRequests.requestMatchers("/", "/user/**", "/shelterPost/**", "/comment/**").permitAll()
                             .anyRequest().authenticated()
             );
         httpSecurity

--- a/src/main/java/com/aeon/hadog/base/dto/comment/commentDTO.java
+++ b/src/main/java/com/aeon/hadog/base/dto/comment/commentDTO.java
@@ -1,0 +1,27 @@
+package com.aeon.hadog.base.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class commentDTO {
+
+    @NotNull
+    private Long commentId;
+
+    @NotNull
+    private String userId;
+
+    @NotNull
+    private LocalDateTime createdDate;
+
+    @NotBlank(message = "내용은 필수 입력 값입니다.")
+    private String content;
+}

--- a/src/main/java/com/aeon/hadog/base/exception/CommentNotFoundException.java
+++ b/src/main/java/com/aeon/hadog/base/exception/CommentNotFoundException.java
@@ -1,0 +1,12 @@
+package com.aeon.hadog.base.exception;
+
+import com.aeon.hadog.base.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentNotFoundException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/aeon/hadog/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aeon/hadog/base/exception/GlobalExceptionHandler.java
@@ -113,4 +113,20 @@ public class GlobalExceptionHandler {
                 .status(ErrorCode.EMOTIONTRACK_NOT_FOUND.getStatus().value())
                 .body(new ErrorResponseDTO(ErrorCode.EMOTIONTRACK_NOT_FOUND));
     }
+
+    @ExceptionHandler(PetIdNotFoundException.class)
+    protected ResponseEntity<ErrorResponseDTO> petIdNotFoundException(final PetIdNotFoundException e) {
+        log.error("PetIdNotFoundException : {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.PET_NOT_FOUND.getStatus().value())
+                .body(new ErrorResponseDTO(ErrorCode.PET_NOT_FOUND));
+    }
+
+    @ExceptionHandler(CommentNotFoundException.class)
+    protected ResponseEntity<ErrorResponseDTO> commentNotFoundException(final CommentNotFoundException e) {
+        log.error("CommentNotFoundException : {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.COMMENT_NOT_FOUND.getStatus().value())
+                .body(new ErrorResponseDTO(ErrorCode.COMMENT_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/aeon/hadog/controller/CommentController.java
+++ b/src/main/java/com/aeon/hadog/controller/CommentController.java
@@ -1,0 +1,52 @@
+package com.aeon.hadog.controller;
+
+import com.aeon.hadog.base.dto.response.ResponseDTO;
+import com.aeon.hadog.domain.ShelterPostComment;
+import com.aeon.hadog.service.ShelterPostCommentService;
+import com.aeon.hadog.service.ShelterPostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@Controller
+@RequiredArgsConstructor
+@RequestMapping
+public class CommentController {
+
+    private final ShelterPostCommentService commentService;
+
+    // 댓글 작성
+    @PostMapping("/addComment")
+    public ResponseEntity<ResponseDTO> addComment(@AuthenticationPrincipal String userId, @RequestParam Long postId, @RequestParam String content) {
+        commentService.addComment(postId, userId, content);
+        return ResponseEntity
+                .ok()
+                .body(new ResponseDTO(200, true, "댓글 작성 성공", content));
+    }
+
+    // 특정 게시글에 대한 댓글 조회
+    @GetMapping("/comment/{postId}")
+    ResponseEntity<ResponseDTO> getComments(@PathVariable Long postId) {
+        List<ShelterPostComment> comments = commentService.getCommentByShelterPostId(postId);
+
+        return ResponseEntity
+                .ok()
+                .body(new ResponseDTO(200, true, "댓글 조회 성공", comments));
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/delComment/{commentId}")
+    public ResponseEntity<ResponseDTO> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal String userId) {
+        Long deletedCommentId = commentService.deleteComment(commentId, userId);
+
+        return ResponseEntity
+                .ok()
+                .body(new ResponseDTO(200, true, "댓글 삭제 성공", deletedCommentId));
+    }
+
+}

--- a/src/main/java/com/aeon/hadog/domain/ShelterPostComment.java
+++ b/src/main/java/com/aeon/hadog/domain/ShelterPostComment.java
@@ -1,0 +1,40 @@
+package com.aeon.hadog.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name="shelter_post_comment")
+public class ShelterPostComment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long shelterPostCommentId; // 댓글 아이디
+
+    @Column(nullable=false)
+    private Long shelterPostId; // 게시글 아이디
+
+    @Column(nullable=false)
+    private String userId; // 유저 string 아이디
+
+    @Column(nullable=false, columnDefinition = "TEXT")
+    private String content; // 댓글 내용
+
+    @Column(nullable=false)
+    @CreatedDate
+    private LocalDateTime createdDate; // 댓글 작성 날짜
+
+//    @ManyToOne
+//    @JoinColumn(name = "parent_id")
+//    private ShelterPostComment parent;
+
+}

--- a/src/main/java/com/aeon/hadog/repository/ShelterPostCommentRepository.java
+++ b/src/main/java/com/aeon/hadog/repository/ShelterPostCommentRepository.java
@@ -1,0 +1,16 @@
+package com.aeon.hadog.repository;
+
+import com.aeon.hadog.domain.ShelterPost;
+import com.aeon.hadog.domain.ShelterPostComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ShelterPostCommentRepository extends JpaRepository<ShelterPostComment, Long> {
+
+    List<ShelterPostComment> findByShelterPostId(Long shelterPostId);
+
+    ShelterPostComment findByShelterPostCommentId(Long shelterPostCmtId);
+}

--- a/src/main/java/com/aeon/hadog/service/ShelterPostCommentService.java
+++ b/src/main/java/com/aeon/hadog/service/ShelterPostCommentService.java
@@ -1,0 +1,66 @@
+package com.aeon.hadog.service;
+
+import com.aeon.hadog.base.code.ErrorCode;
+import com.aeon.hadog.base.exception.CommentNotFoundException;
+import com.aeon.hadog.base.exception.UserNotFoundException;
+import com.aeon.hadog.domain.ShelterPostComment;
+import com.aeon.hadog.repository.ShelterPostCommentRepository;
+import com.aeon.hadog.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ShelterPostCommentService {
+
+    private final ShelterPostCommentRepository shelterPostCmtRepository;
+    private final UserService userService;
+
+    // 게시글에 대한 댓글 조회
+    public List<ShelterPostComment> getCommentByShelterPostId(Long shelterPost) {
+        return shelterPostCmtRepository.findByShelterPostId(shelterPost);
+    }
+
+    // 댓글 작성
+    @Transactional
+    public Long addComment(Long shelterPostId, String userId, String content) {
+
+        ShelterPostComment comment = ShelterPostComment.builder()
+                .shelterPostId(shelterPostId)
+                .userId(userId)
+                .content(content)
+                .createdDate(LocalDateTime.now())
+                .build();
+
+        shelterPostCmtRepository.save(comment);
+
+        return comment.getShelterPostCommentId();
+    }
+
+    // 댓글 삭제
+    @Transactional
+    public Long deleteComment(Long commentId, String userId) {
+
+
+        if (shelterPostCmtRepository.existsById(commentId)) {
+
+            ShelterPostComment comment = shelterPostCmtRepository.findByShelterPostCommentId(commentId);
+
+            if (comment.getUserId().equals(userId)) {
+
+                shelterPostCmtRepository.deleteById(commentId);
+                return commentId;
+            } else {
+                throw new UserNotFoundException(ErrorCode.USER_NOT_FOUND);
+            }
+
+        } else {
+            throw new CommentNotFoundException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/aeon/hadog/service/UserService.java
+++ b/src/main/java/com/aeon/hadog/service/UserService.java
@@ -18,6 +18,7 @@ import org.springframework.validation.FieldError;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -29,6 +30,10 @@ public class UserService {
     private JwtTokenProvider jwtTokenProvider;
     private PasswordEncoder passwordEncoder =new BCryptPasswordEncoder();
 
+    public Long findById(String userId) { // 스트링아이디를 통해 유저 id 키 찾기
+        Optional<User> user = userRepository.findById(userId);
+        return user.get().getUserId();
+    }
 
     public Long signup(JoinRequestDTO joinRequestDTO) {
 


### PR DESCRIPTION
## Summary
댓글 기능

## Describe your changes
보호소의 입양 공고 게시글 댓글 기능 구현(작성, 삭제, 조회)

## Issue number and link
#43 

## Message to the Reviewer
원래 개인 임보자가 올리는 입양 공고의 댓글 기능을 만들어야 하는데, 아직 없어서 보호소의 입양 공고에도 댓글 기능 추가했어요. 입양 후기글, 보호소 글, 임보자 글 세가지 게시글에 댓글 기능이 들어가는데, domain만 여러 개 있고 나머지 코드들은 통일시키는 게 나은지 생각해보면 좋을 것 같습니다.