### PR TITLE
FEAT: 소셜 로그인 - 구글, 네이버

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'com.h2database:h2'
+
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.security:spring-security-oauth2-client'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/aeon/hadog/base/config/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/aeon/hadog/base/config/security/CustomOAuth2UserService.java
@@ -1,0 +1,63 @@
+package com.aeon.hadog.base.config.security;
+
+import com.aeon.hadog.domain.User;
+import com.aeon.hadog.repository.UserRepository;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private HttpSession httpSession;
+
+    public CustomOAuth2UserService(UserRepository userRepository, HttpSession httpSession){
+        this.userRepository = userRepository;
+        this.httpSession = httpSession;
+    }
+
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+//        if (!attributes.getAttributes().containsKey("id")) {
+//            attributes.getAttributes().put("id", attributes.getId());
+//        }
+
+        User user = saveOrUpdate(attributes);
+
+        return new DefaultOAuth2User(
+                Collections.emptyList(),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey()
+        );
+    }
+
+    private User saveOrUpdate(OAuthAttributes attributes){
+        User user = userRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName()))
+                .orElse(attributes.toEntity());
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/aeon/hadog/base/config/security/OAuthAttributes.java
+++ b/src/main/java/com/aeon/hadog/base/config/security/OAuthAttributes.java
@@ -1,0 +1,66 @@
+package com.aeon.hadog.base.config.security;
+
+import com.aeon.hadog.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String id;
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes){
+        if("naver".equals(registrationId)){
+            return ofNaver("id", attributes);
+        } else if("kakao".equals(registrationId)){
+            return ofKakao("id", attributes);
+        }
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object>attributes){
+        return OAuthAttributes.builder()
+                .name((String)attributes.get("name"))
+                .email((String)attributes.get("email"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object>attributes){
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return OAuthAttributes.builder()
+                .name((String)response.get("name"))
+                .email((String)response.get("email"))
+                .attributes(response)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object>attributes){
+        Map<String, Object> response = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> account = (Map<String, Object>) attributes.get("profile");
+
+        return OAuthAttributes.builder()
+                .name((String)response.get("nickname"))             //.name((String)account.get("nickname"))
+                .email("익명")
+                .attributes(response)
+                .nameAttributeKey(userNameAttributeName)
+                .id(String.valueOf(attributes.get("id")))
+                .build();
+    }
+
+    public User toEntity(){
+        return User.builder()
+                .name(name)
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/com/aeon/hadog/base/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/aeon/hadog/base/config/security/SecurityConfiguration.java
@@ -15,6 +15,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfiguration {
 
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+//    public SecurityConfiguration(CustomOAuth2UserService customOAuth2UserService){
+//        this.customOAuth2UserService = customOAuth2UserService;
+//    }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
@@ -28,6 +34,10 @@ public class SecurityConfiguration {
             );
         httpSecurity
             .addFilterBefore(new JwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+        httpSecurity
+                .oauth2Login(oauth2Login ->
+                        oauth2Login.userInfoEndpoint(userInfoEndpointConfig ->
+                                userInfoEndpointConfig.userService(customOAuth2UserService)));
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/aeon/hadog/controller/AdoptReviewController.java
+++ b/src/main/java/com/aeon/hadog/controller/AdoptReviewController.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 public class AdoptReviewController {
     private final UserRepository userRepository;
 
-    private final UserRepository userRepository;
     private final AdoptReviewService adoptReviewService;
     //대댓글
     private final ReviewCommentRepository reviewCommentRepository;

--- a/src/main/java/com/aeon/hadog/domain/User.java
+++ b/src/main/java/com/aeon/hadog/domain/User.java
@@ -20,10 +20,10 @@ public class User {
     @Column(nullable=false)
     private String name;
 
-    @Column(nullable=false)
+    @Column(nullable=true)
     private String id;
 
-    @Column(nullable=false)
+    @Column(nullable=true)
     private String password;
 
     @Column(nullable=false)
@@ -31,4 +31,9 @@ public class User {
 
     @Column(nullable=false)
     private String email;
+
+    public User update(String name){
+        this.name = name;
+        return this;
+    }
 }

--- a/src/main/java/com/aeon/hadog/repository/UserRepository.java
+++ b/src/main/java/com/aeon/hadog/repository/UserRepository.java
@@ -11,6 +11,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findById(String Id);
 
+    Optional<User> findByUserId(Long Id);
     void deleteById(String Id);
+
+    Optional<User> findByEmail(String email);
 
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<h1>Hello Spring Boot</h1>
+<a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>
+<a href="/oauth2/authorization/naver" class="btn btn-secondary active" role="button">Naver Login</a>
+<a href="/oauth2/authorization/kakao" class="btn btn-secondary active" role="button">Kakao Login</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
소셜 로그인 - 구글과 네이버 구현했습니다.

## Describe your changes
oauth를 통해 구현했습니다. 카카오는 email을 못받아와 아직 구현하지 못했습니다. 소셜 로그인시, 닉네임을 입력받지 못해 닉네임 값을 입력받는 controller가 필요할 것 같습니다.

## Issue number and link
#65

## Message to the Reviewer
