### PR TITLE
Refactor: 로그아웃 기능 - 외래키 제약 조건 수정

### DIFF
--- a/src/main/java/com/aeon/hadog/domain/AdoptReview.java
+++ b/src/main/java/com/aeon/hadog/domain/AdoptReview.java
@@ -22,7 +22,7 @@ public class AdoptReview {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long reviewId;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.REMOVE)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/com/aeon/hadog/domain/Pet.java
+++ b/src/main/java/com/aeon/hadog/domain/Pet.java
@@ -17,7 +17,7 @@ public class Pet {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long petId;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/com/aeon/hadog/domain/User.java
+++ b/src/main/java/com/aeon/hadog/domain/User.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Entity
 @Builder
@@ -35,5 +37,15 @@ public class User {
     public User update(String name){
         this.name = name;
         return this;
+    }
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<AdoptReview> adoptReviews;
+
+    @PreRemove
+    private void removeReviews() {
+        for (AdoptReview review : adoptReviews) {
+            review.setUser(null);  // User와의 관계를 끊어준다.
+        }
     }
 }


### PR DESCRIPTION
## Summary
pet, adoptReview와 연관된 외래키 제약 조건 수정

## Describe your changes
로그아웃 시 Cannot delete or update a parent row: a foreign key constraint fails (`db_hadog`.`pet`, CONSTRAINT `FK9hxka0oqkd15dmqstdarori08` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`)) 오류가 발생했습니다.
외래키 제약 조건을 수정하여 오류를 고쳤습니다.

## Issue number and link
#72 

## Message to the Reviewer
