### PR TITLE
Refacotr: 다이어리 API 오류 수정

### DIFF
--- a/src/main/java/com/aeon/hadog/base/dto/diary/DiaryDTO.java
+++ b/src/main/java/com/aeon/hadog/base/dto/diary/DiaryDTO.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -13,10 +14,12 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Getter
 public class DiaryDTO {
+
+    private Long diaryId;
     @NotNull
     private Long emotionTrackId;
 
-    private LocalDateTime diaryDate;
+    private LocalDate diaryDate;
 
     @NotBlank(message = "내용은 필수 입력 값입니다.")
     private String content;

--- a/src/main/java/com/aeon/hadog/base/dto/emotionTrack/EmotionTrackDTO.java
+++ b/src/main/java/com/aeon/hadog/base/dto/emotionTrack/EmotionTrackDTO.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.*;
 
@@ -15,7 +16,7 @@ import lombok.*;
 public class EmotionTrackDTO {
     private Long emotionTrackId;
     private Long petId;
-    private LocalDateTime emotionDate;
+    private LocalDate emotionDate;
     private Long emotionId;
     private EmotionDTO emotion;
 }

--- a/src/main/java/com/aeon/hadog/controller/DiaryController.java
+++ b/src/main/java/com/aeon/hadog/controller/DiaryController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -47,7 +48,7 @@ public class DiaryController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<ResponseDTO> getDiarys(@AuthenticationPrincipal String userId, @RequestParam LocalDateTime date){
+    public ResponseEntity<ResponseDTO> getDiarys(@AuthenticationPrincipal String userId, @RequestParam LocalDate date){
         List<DiaryDTO> result = diaryService.getDiarys(userId, date);
         return ResponseEntity
                 .ok()

--- a/src/main/java/com/aeon/hadog/domain/Diary.java
+++ b/src/main/java/com/aeon/hadog/domain/Diary.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -27,7 +28,7 @@ public class Diary {
     private Long userId;
 
     @Column(nullable=false)
-    private LocalDateTime diaryDate;
+    private LocalDate diaryDate;
 
     @Column(nullable=false, columnDefinition = "TEXT")
     private String content;

--- a/src/main/java/com/aeon/hadog/domain/EmotionTrack.java
+++ b/src/main/java/com/aeon/hadog/domain/EmotionTrack.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -23,7 +24,7 @@ public class EmotionTrack {
     private Long petId;
 
     @Column(nullable=false)
-    private LocalDateTime emotionDate;
+    private LocalDate emotionDate;
 
     @Column(name = "emotion_id", nullable = false)
     private Long emotionId; // 여전히 존재하지만, 관계 설정 시 충돌 방지

--- a/src/main/java/com/aeon/hadog/repository/DiaryRepository.java
+++ b/src/main/java/com/aeon/hadog/repository/DiaryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -18,6 +19,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     void deleteByDiaryId(Long diaryId);
 
-    @Query("SELECT new com.aeon.hadog.base.dto.diary.DiaryDTO(d.emotionTrack.emotionTrackId, d.diaryDate, d.content) FROM Diary d WHERE d.userId = :userId AND d.diaryDate = :date")
-    List<DiaryDTO> findDiaryDTOByUserIdAndDiaryDate(@Param("userId") Long userId, @Param("date") LocalDateTime date);
+    @Query("SELECT new com.aeon.hadog.base.dto.diary.DiaryDTO(d.diaryId, d.emotionTrack.emotionTrackId, d.diaryDate, d.content) FROM Diary d WHERE d.userId = :userId AND d.diaryDate = :date")
+    List<DiaryDTO> findDiaryDTOByUserIdAndDiaryDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/aeon/hadog/service/DiaryService.java
+++ b/src/main/java/com/aeon/hadog/service/DiaryService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -100,7 +101,7 @@ public class DiaryService {
         return diaryDTO;
     }
 
-    public List<DiaryDTO> getDiarys(String userId, LocalDateTime date){
+    public List<DiaryDTO> getDiarys(String userId, LocalDate date){
         User user = userRepository.findById(userId).orElseThrow(()->new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         List<DiaryDTO> diaries = diaryRepository.findDiaryDTOByUserIdAndDiaryDate(user.getUserId(), date);

--- a/src/test/java/com/aeon/hadog/service/DiaryServiceTest.java
+++ b/src/test/java/com/aeon/hadog/service/DiaryServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -181,7 +182,7 @@ class DiaryServiceTest {
     void getDiarys() {
         // given
         String userId = "user3";
-        LocalDateTime date = LocalDateTime.of(2024, 5, 2, 0, 0);
+        LocalDate date = LocalDate.of(2024, 5, 2);
         List<DiaryDTO> diaries = diaryRepository.findDiaryDTOByUserIdAndDiaryDate(4L, date);
 
         // when


### PR DESCRIPTION
## Summary
- 날짜별 목록 조회가 가능하도록 LocalDateTime에서 LocalDate로 수정
- 목록조회에서 diaryId값을 response에 포함

## Describe your changes
- Diary, EmotionTrack의 날짜 부분을 LocalDateTime에서 LocalDate로 수정했습니다.
- 관련 DTO, Service 수정했습니다.

## Issue number and link


## Message to the Reviewer
